### PR TITLE
Allow complex filenames

### DIFF
--- a/src/Migrondi.Tests/Tests.fs
+++ b/src/Migrondi.Tests/Tests.fs
@@ -109,7 +109,7 @@ type TestUtils() =
     member this.CreateNewMigrationFile_WithComplexNameTest() =
         let randomName n = 
             let r = Random()
-            let chars = Array.concat([[|'a' .. 'z'|]; [|'A' .. 'Z'|]; [|'0' .. '9'|]])
+            let chars = Array.concat([[|'a' .. 'z'|]; [|'A' .. 'Z'|]; [|'0' .. '9'|]; [|'!'; '@'; ' '; '_'; '#'; '%'|]])
             let sz = Array.length chars in
             String(Array.init n (fun _ -> chars.[r.Next sz]))
 

--- a/src/Migrondi.Tests/Tests.fs
+++ b/src/Migrondi.Tests/Tests.fs
@@ -104,3 +104,27 @@ type TestUtils() =
         Assert.IsTrue(file.Name.Contains ".sql")
         Assert.IsTrue(content.Contains "MIGRONDI:UP")
         Assert.IsTrue(content.Contains "MIGRONDI:DOWN")
+
+    [<TestMethod>]
+    member this.CreateNewMigrationFile_WithComplexNameTest() =
+        let randomName n = 
+            let r = Random()
+            let chars = Array.concat([[|'a' .. 'z'|]; [|'A' .. 'Z'|]; [|'0' .. '9'|]])
+            let sz = Array.length chars in
+            String(Array.init n (fun _ -> chars.[r.Next sz]))
+
+        let name = randomName 20
+        let tempPath =
+            Path.Combine(Path.GetTempPath(), name)
+
+        Directory.CreateDirectory tempPath |> ignore
+
+        let file, content =
+            createNewMigrationFile tempPath name
+
+        let content = Encoding.UTF8.GetString content
+        Assert.IsTrue(file.Name.Contains name)
+        Assert.IsTrue(file.Name.Contains "_")
+        Assert.IsTrue(file.Name.Contains ".sql")
+        Assert.IsTrue(content.Contains "MIGRONDI:UP")
+        Assert.IsTrue(content.Contains "MIGRONDI:DOWN")

--- a/src/Migrondi/Utils.fs
+++ b/src/Migrondi/Utils.fs
@@ -73,7 +73,7 @@ module Utils =
 
     let createNewMigrationFile (path: string) (name: string) =
         let timestamp =
-            System.DateTimeOffset.Now.ToUnixTimeMilliseconds()
+            DateTimeOffset.Now.ToUnixTimeMilliseconds()
 
         let name =
             sprintf "%s_%i.sql" (name.Trim()) timestamp


### PR DESCRIPTION
Hello! This PR addresses enhancement #8 

It replaces the previous mechanism that validates a migration file name with a regex that gives the user more flexibility when writing the file names while ensuring we still have the timestamp we need.

This change did not break the existing test, so I added a new one that generates a random string including spaces and special characters for the file name. Also did manual testing with some weird file names and the migration (both up and down) still work fine:
![image](https://user-images.githubusercontent.com/1923678/102685993-7265ad80-4199-11eb-80b3-bff9d1fe9ecf.png)

Let me know if you need any edits =)

Thanks!