### PR TITLE
Experimental/fscripts

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        dotnet: [ '3.1.x', '5.0.x' ]
+        dotnet: [ '5.0.x' ]
 
     steps:
     - uses: actions/checkout@v2
@@ -20,10 +20,6 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: '5.0.x'
-    - name: Setup dotnet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '3.1.x'
     - run: dotnet build src --configuration Release
     - run: dotnet test src/Migrondi.Tests --verbosity normal
 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,6 +4,7 @@
     // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
     "configurations": [
+
         {
             "name": "Debug Init Command",
             "type": "coreclr",
@@ -61,7 +62,22 @@
             "console": "internalConsole"
         },
         {
-            "name": "Debug DOWN Command",
+            "name": "Debug up --dry-run",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            "program": "${workspaceFolder}/src/Migrondi/bin/Debug/netcoreapp3.1/Migrondi.dll",
+            "args": [
+                "up",
+                "--dry-run",
+                "true"
+            ],
+            "cwd": "${workspaceFolder}",
+            "stopAtEntry": false,
+            "console": "internalConsole"
+        },
+        {
+            "name": "Debug down",
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build",
@@ -72,6 +88,21 @@
             "cwd": "${workspaceFolder}",
             "stopAtEntry": false,
             "console": "internalConsole",
+        },
+        {
+            "name": "Debug down --dry-run",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            "program": "${workspaceFolder}/src/Migrondi/bin/Debug/netcoreapp3.1/Migrondi.dll",
+            "args": [
+                "down",
+                "--dry-run",
+                "true"
+            ],
+            "cwd": "${workspaceFolder}",
+            "stopAtEntry": false,
+            "console": "internalConsole"
         },
         {
             "name": "Debug down -t 1",

--- a/src/Migrondi/Migrondi.fsproj
+++ b/src/Migrondi/Migrondi.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Description>
       This is a simple SQL migrations tool, it runs sql files against a database each migration is enclosed within a transaction, databases supported: SQLServer, SQLite
     </Description>
@@ -21,6 +21,7 @@
   <ItemGroup>
     <Compile Include="Types.fs" />
     <Compile Include="Options.fs" />
+    <Compile Include="ScriptedContent.fs" />
     <Compile Include="Utils.fs" />
     <Compile Include="Queries.fs" />
     <Compile Include="Migrations.fs" />
@@ -29,6 +30,8 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.7.82" />
     <PackageReference Include="CommandLineParser.FSharp" Version="2.7.82" />
+    <PackageReference Include="FSharp.Compiler.Service" Version="38.0.2" />
+    <PackageReference Include="FSharp.SystemTextJson" Version="0.15.14" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="1.1.1" />
     <PackageReference Include="Microsoft.Data.SQLite" Version="3.1.3" />
     <PackageReference Include="RepoDb" Version="1.10.11" />

--- a/src/Migrondi/ScriptedContent.fs
+++ b/src/Migrondi/ScriptedContent.fs
@@ -1,0 +1,49 @@
+namespace Migrondi
+
+open System
+open System.IO
+open FSharp.Compiler.SourceCodeServices
+open FSharp.Compiler.Interactive.Shell
+open Types
+
+module ScriptedContent =
+
+    let getContentFromScripts (file: FileInfo): string * string =
+        let defConfig =
+            FsiEvaluationSession.GetDefaultConfiguration()
+
+        let argv =
+            [| "fsi.exe"
+               "--noninteractive"
+               "--nologo"
+               "--gui-" |]
+
+        use stdIn = new StringReader("")
+        use stdOut = new StringWriter()
+        use stdErr = new StringWriter()
+
+        use session =
+            FsiEvaluationSession.Create(defConfig, argv, stdIn, stdOut, stdErr)
+
+
+        let interaction =
+            use script = file.OpenText()
+            session.EvalInteractionNonThrowing(script.ReadToEnd())
+
+
+        match interaction with
+        | Choice2Of2 ex, error -> raise (ex)
+        | Choice1Of2 None, error -> failwith $"Unsuported type %A{error}"
+        | Choice1Of2 (Some value), error ->
+            match value.ReflectionValue with
+            | :? (list<list<string>>) as migrations ->
+                let up =
+                    (List.tryHead migrations |> Option.defaultValue [])
+                    |> List.reduce (fun next curr -> $"{next}\n{curr}")
+
+                let down =
+                    (List.tryLast migrations |> Option.defaultValue [])
+                    |> List.reduce (fun next curr -> $"{next}\n{curr}")
+
+                $"\n{up}", $"\n{down}"
+            | _ -> failwith $"Unsuported type %A{value.ReflectionType}"

--- a/src/Migrondi/ScriptedContent.fs
+++ b/src/Migrondi/ScriptedContent.fs
@@ -23,7 +23,7 @@ module ScriptedContent =
         use stdErr = new StringWriter()
 
         use session =
-            FsiEvaluationSession.Create(defConfig, argv, stdIn, stdOut, stdErr)
+            FsiEvaluationSession.Create(defConfig, argv, stdIn, stdOut, stdErr, true)
 
 
         let interaction =

--- a/src/Migrondi/Types.fs
+++ b/src/Migrondi/Types.fs
@@ -9,7 +9,8 @@ module Types =
     type MigrondiConfig =
         { connection: string
           migrationsDir: string
-          driver: string }
+          driver: string
+          style: string option }
 
     [<CLIMutable>]
     [<Map("migration")>]
@@ -20,6 +21,7 @@ module Types =
 
     type MigrationFile =
         { name: string
+          ext: string
           timestamp: int64
           upContent: string
           downContent: string }
@@ -45,9 +47,11 @@ module Types =
             | others ->
                 let drivers = "mssql | sqlite | postgres | mysql"
 
-                raise
-                    (ArgumentException
-                        (sprintf "The driver selected \"%s\" does not match the available drivers  %s" others drivers))
+                raise (
+                    ArgumentException(
+                        sprintf "The driver selected \"%s\" does not match the available drivers  %s" others drivers
+                    )
+                )
 
     [<RequireQualifiedAccess>]
     type MigrationSource =


### PR DESCRIPTION
this pr takes a jab at #10 so far it seems to work just fine, but it requires actual testing to see what can go wrong and to catch any unexpected usages there might be

Also while we "collect" the FSI Session at the end of the function, I'm not sure if bigger scripts can kick up ram usage or cause memory issues

**edit**:
There's a new option for migrondi.json
```jsonc
{
  "connection": "Data Source=migrondi.db",
  "migrationsDir": "migrations\\",
  "driver": "sqlite",
  "style": "fsx" //<- fsx or sql, if it doesn't exist the scripts default to sql
}
```
