### PR TITLE
ci: bump actions, add path filters, pin SDK to 10.0.100, refresh AGENTS.md

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,14 +1,20 @@
 name: Docs
 
-# Trigger this Action when new code is pushed to the main branch
+# Trigger this Action when documentation source or the documented code changes
 on:
   push:
     branches:
       - vnext
+    paths:
+      - docs/**
+      - src/**
+      - Directory.Build.props
+      - .config/dotnet-tools.json
+      - .github/workflows/docs.yml
 
 # We need some permissions to publish to Github Pages
 permissions:
-  contents: write
+  contents: read
   pages: write
   id-token: write
 
@@ -16,16 +22,16 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.0.x
       - name: Restore tools
         run: dotnet tool restore
       - name: Build code
         run: dotnet build -c Release
-      - name: Generate the documentation'
+      - name: Generate the documentation
         run: dotnet fsdocs build --properties Configuration=Release
       - name: Upload documentation
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -3,16 +3,26 @@ name: .NET Core
 on:
   push:
     branches: [main, vnext]
+    paths:
+      - src/**
+      - global.json
+      - Directory.Build.props
+      - .github/workflows/dotnetcore.yml
   pull_request:
     branches: [main, vnext]
+    paths:
+      - src/**
+      - global.json
+      - Directory.Build.props
+      - .github/workflows/dotnetcore.yml
 
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: "10.0.x"
       - name: Restore

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -51,7 +51,7 @@ jobs:
 
       - name: Setup .NET
         if: steps.check_tag.outputs.exists == 'false'
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.0.x
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,7 +83,6 @@ Also parsed (JSON, via Thoth): keys `connection`, `migrations` (the migrations d
 ### Build
 
 ```bash
-# Full build with FsMake
 dotnet build
 
 # Direct dotnet build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,14 +4,87 @@ Instructions for agentic coding assistants working on the Migrondi codebase.
 
 ## Project Overview
 
-SQL migrations tool built in F# targeting .NET 8.0 and .NET 9.0. Uses F# with .fsi signature files, MSTest for testing, and Fantomas for formatting.
+Migrondi is a SQL migrations tool: you write versioned `.sql` files and it tracks which have been applied to a database — applying pending ones ("up") or rolling applied ones back ("down"), plus dry-run, list, and per-file status checks. It runs each migration inside a transaction (with an opt-out `manualTransaction` flag for statements like `CREATE INDEX CONCURRENTLY`) and supports **SQLite, SQL Server (MSSQL), PostgreSQL, and MySQL** over ADO.NET (see the `MigrondiDriver` DU).
+
+The repo ships three independently useful components built on one engine:
+
+- **`Migrondi.Core`** — the packable migration library. The `IMigrondi` service (built via `Migrondi.MigrondiFactory`) coordinates the file system and database: create migrations, apply/rollback (optionally a count), dry-run, and list status. Migration content is read through a pluggable `IMiMigrationSource` — the default reads SQL from disk, but you can supply a custom source (HTTP, S3, blob storage, …). The public API is CLS-friendly (sync + async overloads, `Result` extensions), so it embeds cleanly into F#/C#/VB applications.
+- **`Migrondi`** — the CLI, distributed as a `dotnet` global tool (`migrondi`) and as self-contained single-file binaries for Windows/macOS/Linux (x64 + arm64). Commands: `init`, `new`, `up`/`apply`, `down`/`rollback`, `list`/`show`, `status` (each with aliases).
+- **`MigrondiUI`** — an Avalonia desktop app that also runs as an **MCP (Model Context Protocol) server**. As a UI it manages multiple migration "projects" (on-disk local projects and virtual projects stored in its own database). In MCP mode it exposes those projects and migration operations (create/update/delete migrations, dry-run, apply, rollback, import/export) as tools, so an AI agent can drive migrations over MCP (MCP operations target virtual projects).
+
+The codebase uses F# with `.fsi` signature files, MSTest for tests, and Fantomas for formatting.
+
+## Imperatives
+
+1. **NEVER PUSH WITHOUT PERMISSION.** Always ask before pushing to the remote.
+2. **NEVER FORCE PUSH.** Tell the user they have to force push instead of you.
+3. **Always run `dotnet fantomas .` before committing code.** Format all F# files before staging.
+4. **Never use `Option.get` or `ValueOption.get`.** Always pattern match (`match`, `function`, `if ... then`) or use safe alternatives (`Option.defaultValue`, `Option.map`, `Array.choose`, etc.) to handle option values. Unchecked `.get` calls crash at runtime on `None`.
+5. Pull requests made with the `gh` command should use a markdown file as the PR body, not inline escaped markdown strings.
+
+## Project Structure
+
+- `src/Migrondi.Core` — the packable migration library/engine.
+- `src/Migrondi` — the CLI (global tool + self-contained binaries).
+- `src/MigrondiUI` — the Avalonia app and MCP server.
+- `src/Migrondi.Tests`, `src/MigrondiUI.Tests` — test projects (not packable).
+- `samples/` — sample usage.
+- `docs/` — the [FsDocs](https://fsprojects.github.io/FSharp.Formatting/) documentation site.
+
+> Target frameworks, package versions, and similar build details live in each project's `.fsproj` and `Directory.Build.props` — read those directly rather than relying on this file, since they change over time.
+
+## Migration File Format
+
+Migration `.sql` files are **parsed by strict regex**, not free-form text. The `-- MIGRONDI:` lines and the `UP`/`DOWN` delimiters carry data — never delete, reorder, reformat, or "tidy" them (the files themselves say `-- Do not remove MIGRONDI comments.`). The authoritative parser is `src/Migrondi.Core/Serialization.fs` (`Migration.EncodeText` / `Migration.DecodeText`); filename matching lives in `Library.fsi` (`Matcher.V0` / `Matcher.V1`). When in doubt, read those.
+
+### V1 format — current; used for all new migrations
+
+```sql
+-- MIGRONDI:NAME=add_users
+-- MIGRONDI:TIMESTAMP=1586550686936
+-- MIGRONDI:ManualTransaction=true
+-- ---------- MIGRONDI:UP ----------
+CREATE TABLE users (id INTEGER PRIMARY KEY);
+-- ---------- MIGRONDI:DOWN ----------
+DROP TABLE users;
+```
+
+- Metadata lines are `-- MIGRONDI:KEY=VALUE`; both `KEY` and `VALUE` may only contain `[a-zA-Z0-9_-]+`.
+  - `NAME` and `TIMESTAMP` (an `int64`) are required.
+  - `ManualTransaction=true|false` is optional — emitted only when `true`; absent or any non-`true` value means `false`.
+- Section delimiters must be **exactly** `-- ---------- MIGRONDI:UP ----------` and `-- ---------- MIGRONDI:DOWN ----------` (mind the dashes). "Up" content is everything between the two delimiters; "Down" (rollback) content is everything after the DOWN delimiter. Both are trimmed.
+- Set `ManualTransaction=true` only for statements that can't run inside a transaction (e.g. `CREATE INDEX CONCURRENTLY`); otherwise omit it so the migration runs in a transaction and rolls back on failure.
+
+### V0 format — pre-v1, deprecated (read-only)
+
+```sql
+-- ---------- MIGRONDI:UP:1586550686936 ----------
+CREATE TABLE users (id INTEGER PRIMARY KEY);
+-- ---------- MIGRONDI:DOWN:1586550686936 ----------
+DROP TABLE users;
+```
+
+- The timestamp is embedded in the delimiter (`MIGRONDI:UP:<ts>` / `MIGRONDI:DOWN:<ts>`); the name comes from the **filename**, and `manualTransaction` is always `false`.
+- A file is decoded as V0 if it contains a `-- ---------- MIGRONDI:UP|DOWN:<digits> ----------` line. **Never create V0 files** — the parser only reads legacy ones for backwards compatibility.
+
+### Filenames
+
+- **V1 (current):** `<timestamp>_<name>.sql` — e.g. `1586550686936_add_users.sql`.
+- **V0 (legacy):** `<name>_<timestamp>.sql`. Both are still recognized when migrations are listed.
+- Extension must be `.sql` or `.SQL`; `name` matches `[a-zA-Z0-9_-]+` (enforced by `MigrationName.Validate`).
+- Prefer creating migrations through the CLI (`migrondi new`), the UI, or the MCP tools — they generate the correct filename and V1 body. If you hand-author one, match V1 exactly.
+
+### `migrondi.json` (project config)
+
+Also parsed (JSON, via Thoth): keys `connection`, `migrations` (the migrations directory), `driver`, and optional `tableName` (defaults to `__migrondi_migrations`). `driver` accepts `sqlite`, `mssql`/`sqlserver`, `postgres`/`postgressql`, `mysql`/`mariadb`. Keep it valid JSON with those keys.
 
 ## Build and Test Commands
 
 ### Build
+
 ```bash
 # Full build with FsMake
-dotnet fsi build.fsx
+dotnet build
 
 # Direct dotnet build
 dotnet build src/Migrondi/Migrondi.fsproj
@@ -22,12 +95,10 @@ dotnet fsi build.fsx build:runtime -- linux-x64
 ```
 
 ### Test
+
 ```bash
 # Run all tests
-dotnet test src/Migrondi.Tests --no-restore
-
-# Run tests using FsMake
-dotnet fsi build.fsx test
+dotnet test src/Migrondi.Tests
 
 # Run single test
 dotnet test src/Migrondi.Tests --filter "FullyQualifiedName=Namespace.ClassName.MethodName"
@@ -37,102 +108,80 @@ dotnet test src/Migrondi.Tests -f net8.0 --no-restore
 ```
 
 ### Format and Lint
-```bash
-# Format all F# source files
-dotnet fsi build.fsx format
-# Or directly
-dotnet fantomas format
-```
 
-### Restore
 ```bash
-dotnet restore
+dotnet fantomas . # or relative path to the file
 ```
 
 ### Run CLI
+
 ```bash
 dotnet run --project src/Migrondi -- <command>
 ```
 
-## Code Style
-
-### Formatting (.editorconfig)
-- Indentation: 2 spaces
-- Max line length: 80 characters
-- Trim trailing whitespace, LF (Unix) line endings
-- Stroustrup-style multiline brackets
-- Multiline lambdas close on new line
-
-### Namespace/Module Conventions
-- Core: `namespace Migrondi.Core` or `namespace Migrondi.Core.*`
-- CLI: `namespace Migrondi.*`
-- Tests: `namespace Migrondi.Tests.*`
-- Internal modules: `module internal ModuleName`
-- Private modules: `module private ModuleName`
-- Auto-open: `[<AutoOpen>] module ModuleName`
-- Qualified access: `[<RequireQualifiedAccess>]` on types/modules
-
-### Import Order
-1. System namespaces
-2. Microsoft namespaces
-3. Third-party (FsToolkit, IcedTasks, Thoth.Json)
-4. Project namespaces (Migrondi.*)
-
-### Type Conventions
-- Records: PascalCase fields, anonymous records lowercase
-- DUs: `[<RequireQualifiedAccess>]`, PascalCase cases
-- Functions: camelCase (private), PascalCase (public API)
-- Async: `IcedTasks`, `Async` suffix, optional `?cancellationToken`
-
-### Error Handling
-Use `FsToolkit.ErrorHandling`:
-- `Validation<'T, 'E>` for multiple errors
-- `Result<'T, 'E>` for single error
-- Return errors as string lists
-
-Define exceptions in `Library.fs`: `exception MyError of Context: string * Reason: string`
-
 ### Public API Guidelines
+
 **Critical:** No F#-specific types for C#/VB interop (use `seq` not `list`, `T option` not `'T option`). Document with XML comments. Provide sync and async versions.
 
 ### Signature Files (.fsi)
+
 Core library uses .fsi files before .fs in project order. Include full type signatures and XML docs.
-
-### Testing (MSTest)
-```fsharp
-[<TestClass>]
-type MyTests() =
-  [<TestInitialize>]
-  member _.Setup() = // setup code
-
-  [<TestCleanup>]
-  member _.Cleanup() = // cleanup code
-
-  [<TestMethod>]
-  [<DataRow("input1", "expected1")>]
-  member _.``Test description``(input, expected) =
-    Assert.AreEqual(expected, input)
-```
-- Descriptive names with backticks
-- `[<DataRow>]` for parameterized tests
-- `task { ... }` for async tests
-
-### File Organization
-**Migrondi.Core.fsproj:** Library.fsi/fs, Serialization.fsi/fs, FileSystem.fsi/fs, Database.fsi/fs, Migrondi.fsi/fs
-
-**Migrondi.Tests.fsproj:** Library.fs, Serialization.fs, FileSystem.fs, Database.fs, Database.Async.fs, Migrondi.fs, Main.fs
-
-### Common Patterns
-- **URIs for paths:** Use `Uri(path, UriKind.Relative/Absolute)` internally
-- **Logging:** `Microsoft.Extensions.Logging`, inject `ILogger<T>`, structured logging
-- **Transactions:** Database transactions for migrations, rollback on failure
+When using signature files, by default all code is private to the module, only what is declared in the .fsi file is exposed.
+you can still declare private or internal in the fsi file to expose things for testing but it is not encouraged.
 
 ## CI/CD
 
-GitHub Actions: `dotnet restore`, `dotnet build src/Migrondi -f net9.0 --configuration Release`, `dotnet test src/Migrondi.Tests --no-restore`
+GitHub Actions live in `.github/workflows/`:
 
-## Resources
-- Fantomas: https://github.com/fsprojects/fantomas
-- FsToolkit.ErrorHandling: https://github.com/fsprojects/FsToolkit.ErrorHandling
-- IcedTasks: https://github.com/TheAngryByrd/IcedTasks
-- MSTest: https://learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-with-mstest
+- `dotnetcore.yml` — restores, builds, and tests `Migrondi.slnx` on .NET 10, on `main`/`vnext` pushes and PRs.
+- `docs.yml` — builds the FsDocs site and deploys it to GitHub Pages (from `vnext`).
+- `release.yml` — a `workflow_dispatch` release: extracts the version from `CHANGELOG.md`, runs tests, packs the NuGet packages, publishes self-contained CLI/UI binaries for `linux`/`osx`/`win` (x64/arm64), and creates a GitHub Release.
+
+## Changelog Management
+
+We follow https://github.com/ionide/KeepAChangelog guidelines.
+
+Changelog format:
+
+```markdown
+# Changelog
+
+## [Unreleased]
+
+Content that is pending for release goes here.
+
+## [1.0.0] - 2026-06-24
+
+### Added
+
+- Initial release
+```
+
+Each section may contain the following categories:
+
+- Added
+- Changed
+- Deprecated
+- Removed
+- Fixed
+- Security
+
+When adding entries to the changelog, make sure to follow format and categories.
+
+### Writing style
+
+The changelog is written for **developers upgrading their version**, not as a development journal. Keep these rules in mind:
+
+1. **Concise and reader-focused.** Each entry is one bullet that says what changed and why a user cares — not how it's implemented internally. No internal module/file paths, no build/milestone/phase numbers (e.g. "B12", "Phase 3"), no section references (e.g. "§6.2"), and no "mirrors the canonical X" narration. A reader should understand the entry without reading the code.
+
+2. **Group by user-facing concern, not by task.** One bullet per feature/fix area. If multiple commits touch the same subsystem, collapse them into one bullet that names each fix briefly, rather than one bullet per commit.
+
+3. **Only released code can be Changed or Fixed.** Features that have never shipped belong in `Added` — there is no prior version to change from or fix against. Design choices and implementation details of a new feature are part of its `Added` description, not separate `Fixed`/`Changed` entries. Use `Changed`/`Fixed` only for modifications to already-released behavior (and mark breakage with **Breaking:** or **Breaking (behavioral):**).
+
+4. **Lead with the affected surface.** Bold-prefix each bullet with the area: `**Migrondi:**`, `**Migrondi.Core:**`, `**MigrondiUI:**`, `**CI:**`, `**Project:**`, etc. Keep breaking changes at the top of their category.
+
+5. **Plain language.** Describe the user-visible effect, not the code diff. The reader wants to know what they'll observe, not what line changed.
+
+### Versioning
+
+The package version is derived from `CHANGELOG.md` at pack time by `Ionide.KeepAChangelog.Tasks` (wired in `Directory.Build.props`), and applies to every packable project. There is no need to edit versions in project files or CI manually. Cutting a release is done by moving the desired content from `[Unreleased]` into a new version section, then triggering the **Create Release** workflow.

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
-    "version": "10.0.301",
+    "version": "10.0.100",
     "allowPrerelease": false,
-    "rollForward": "latestPatch"
+    "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
## Summary

Tunes Migrondi's CI to match the pattern used across the Navs/JDeck/Hox family, pins the SDK more leniently, and refreshes `AGENTS.md` (including the migration-file format agents must respect).

## Workflows (`.github/workflows/`)

- **Action bumps** in all three: `actions/checkout@v4 → @v6`, `actions/setup-dotnet@v4 → @v5`.
- **`dotnetcore.yml`** — added path filters (`src/**`, `global.json`, `Directory.Build.props`, the workflow file) so build/test only run when build inputs change.
- **`docs.yml`** — added path filters (`docs/**`, `src/**`, `Directory.Build.props`, `.config/dotnet-tools.json`, the workflow file); least-privilege `contents: write → read`. Stays on `vnext`.
- **`release.yml`** — action bumps only. Unchanged: `NUGET_API_KEY`, changelog-driven flow, CLI/UI self-contained binary publishing (linux/osx/win × x64/arm64), GitHub Release.
- Workflow **names** and `build.fsx` left as-is on purpose.

## `global.json`

`10.0.301` / `latestPatch` → **`10.0.100` / `latestFeature`** (keeps `allowPrerelease: false`). Matches the other repos and lowers the contributor bar — anyone with a 10.0.x SDK can build; `latestFeature` still picks the highest installed feature band.

## `AGENTS.md`

- Rewrote **Project Overview** from the codebase (not the README): the `IMigrondi`/`MigrondiFactory` engine, `IMiMigrationSource` extensibility, CLI commands, and the MigrondiUI desktop + MCP server roles.
- **Removed stale, rot-prone detail** (the old "targets .NET 8.0/9.0" line, the wrong CI command) and pointed to each `.fsproj`/`Directory.Build.props` for target frameworks/versions.
- Added the family **Imperatives** and **Changelog Management** sections.
- Added a **Migration File Format** section (the critical one): the `-- MIGRONDI:` metadata + `UP`/`DOWN` delimiters are regex-parsed and must not be edited; documents the **V1** format (current), the **V0** format (pre-v1, read-only), filename schemas, and `migrondi.json`. Points at `Serialization.fs` / `Library.fsi` as the source of truth.

## Verified

- Targeting already satisfies the constraints: `Migrondi.Core` = `net8.0;net10.0`; CLI/UI binaries publish on `net10.0` (latest LTS). No open issue requests a specific .NET version (#38, closed, was a net8 tool-install failure already covered by the CLI's `net8` target).
- YAML + `global.json` validate.
