### PR TITLE
fix: SQL Server migrations and CLI command eagerness (#40)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,12 @@
 - Aligned Serilog.Extensions.Logging to 10.0.0 and Serilog.Sinks.Console to 6.1.1 in MigrondiUI
 - Simplified CI workflow to a single build+test job
 - Removed dead `MigrondiExt.fs` — superseded by `MigrationOperationsFactory` in Services.fs
+- **Project:** Updated FSharp.SystemCommandLine from 2.0.0-beta5.3 to the stable 2.1.0 release
 
 ### Fixed
 
+- **Migrondi.Core:** Applying or rolling back migrations against SQL Server failed. The migrations history table is now created with an auto-incrementing id, without the `GO` statement (invalid over the data provider), and without a hard-coded `dbo` schema, so it respects the connection's default schema. The async "last applied" lookup also uses SQL Server's `TOP 1` rather than the unsupported `LIMIT 1`.
+- **Migrondi:** Commands that don't touch the database (`new`, `init`, `--help`) crashed at startup whenever the configured database was unreachable or used a non-SQLite driver. Database setup now runs only for the commands that actually need it.
 - MCP `StructuredContent` type compatibility with ModelContextProtocol 1.4.0 (`JsonNode` → `Nullable<JsonElement>`)
 - CI workflow attempting to build Migrondi.Core for net9.0 (target no longer exists)
 

--- a/src/Migrondi.Core/Database.fs
+++ b/src/Migrondi.Core/Database.fs
@@ -567,6 +567,25 @@ module MigrationsAsyncImpl =
         return None
     }
 
+  let readMigrationRecords (reader: DbDataReader) (token: CancellationToken) = cancellableTask {
+    let records = ResizeArray<MigrationRecord>()
+    let mutable more = true
+
+    while more do
+      let! hasRow = reader.ReadAsync(token)
+
+      if hasRow then
+        records.Add {
+          id = reader.GetInt32(0)
+          name = reader.GetString(1)
+          timestamp = reader.GetInt64(2)
+        }
+      else
+        more <- false
+
+    return List.ofSeq records
+  }
+
   let listMigrationsAsync (connection: DbConnection) (tableName: string) = cancellableTask { // Changed signature
     let! token = CancellableTask.getCancellationToken() // Get token from context
     use command = connection.CreateCommand()
@@ -576,14 +595,7 @@ module MigrationsAsyncImpl =
 
     use! reader = command.ExecuteReaderAsync(token) // Use token
 
-    return [ // Using list comprehension
-      while reader.Read() do
-        {
-          id = reader.GetInt32(0)
-          name = reader.GetString(1)
-          timestamp = reader.GetInt64(2)
-        }
-    ]
+    return! readMigrationRecords reader token
   }
 
   let runQueryAsync
@@ -739,14 +751,7 @@ module MigrationsAsyncImpl =
 
       use! reader = command.ExecuteReaderAsync(token)
 
-      return [ // Using list comprehension
-        while reader.Read() do
-          {
-            id = reader.GetInt32(0)
-            name = reader.GetString(1)
-            timestamp = reader.GetInt64(2)
-          }
-      ]
+      return! readMigrationRecords reader token
     }
 
   let rollbackMigrationsAsync
@@ -781,14 +786,8 @@ module MigrationsAsyncImpl =
 
         use! reader = command.ExecuteReaderAsync(token)
 
-        rolledBackRecords <- [
-          while reader.Read() do
-            {
-              id = reader.GetInt32(0)
-              name = reader.GetString(1)
-              timestamp = reader.GetInt64(2)
-            }
-        ]
+        let! records = readMigrationRecords reader token
+        rolledBackRecords <- records
 
       for migration in migrationsToRollback do
         let content = migration.downContent

--- a/src/Migrondi.Core/Database.fs
+++ b/src/Migrondi.Core/Database.fs
@@ -554,7 +554,9 @@ module MigrationsAsyncImpl =
 
       use! reader = command.ExecuteReaderAsync(token) // Use token
 
-      if reader.Read() then
+      let! hasRow = reader.ReadAsync(token)
+
+      if hasRow then
         return
           Some {
             id = reader.GetInt32(0)

--- a/src/Migrondi.Core/Database.fs
+++ b/src/Migrondi.Core/Database.fs
@@ -567,21 +567,16 @@ module MigrationsAsyncImpl =
         return None
     }
 
-  let readMigrationRecords (reader: DbDataReader) (token: CancellationToken) = cancellableTask {
+  let readMigrationRecords(reader: DbDataReader) = cancellableTask {
+    let! token = CancellableTask.getCancellationToken()
     let records = ResizeArray<MigrationRecord>()
-    let mutable more = true
 
-    while more do
-      let! hasRow = reader.ReadAsync(token)
-
-      if hasRow then
-        records.Add {
-          id = reader.GetInt32(0)
-          name = reader.GetString(1)
-          timestamp = reader.GetInt64(2)
-        }
-      else
-        more <- false
+    while! reader.ReadAsync token do
+      records.Add {
+        id = reader.GetInt32 0
+        name = reader.GetString 1
+        timestamp = reader.GetInt64 2
+      }
 
     return List.ofSeq records
   }
@@ -593,9 +588,9 @@ module MigrationsAsyncImpl =
     command.CommandText <-
       $"SELECT id, name, timestamp FROM %s{tableName} ORDER BY timestamp DESC"
 
-    use! reader = command.ExecuteReaderAsync(token) // Use token
+    use! reader = command.ExecuteReaderAsync token
 
-    return! readMigrationRecords reader token
+    return! readMigrationRecords reader
   }
 
   let runQueryAsync
@@ -749,9 +744,9 @@ module MigrationsAsyncImpl =
 
       command.CommandText <- Queries.getAllResultsQuery tableName
 
-      use! reader = command.ExecuteReaderAsync(token)
+      use! reader = command.ExecuteReaderAsync token
 
-      return! readMigrationRecords reader token
+      return! readMigrationRecords reader
     }
 
   let rollbackMigrationsAsync
@@ -784,9 +779,9 @@ module MigrationsAsyncImpl =
           param.Value <- name
           command.Parameters.Add(param) |> ignore)
 
-        use! reader = command.ExecuteReaderAsync(token)
+        use! reader = command.ExecuteReaderAsync token
 
-        let! records = readMigrationRecords reader token
+        let! records = readMigrationRecords reader
         rolledBackRecords <- records
 
       for migration in migrationsToRollback do

--- a/src/Migrondi.Core/Database.fs
+++ b/src/Migrondi.Core/Database.fs
@@ -167,13 +167,12 @@ module Queries =
   timestamp BIGINT NOT NULL
 );"""
     | MigrondiDriver.Mssql ->
-      $"""IF OBJECT_ID(N'dbo.{tableName}', N'U') IS NULL
-CREATE TABLE dbo.%s{tableName}(
-  id INT PRIMARY KEY,
+      $"""IF OBJECT_ID(N'%s{tableName}', N'U') IS NULL
+CREATE TABLE %s{tableName}(
+  id INT IDENTITY(1,1) PRIMARY KEY,
   name VARCHAR(255) NOT NULL,
   timestamp BIGINT NOT NULL
-);
-GO"""
+);"""
 
   let getFirstResultQuery(tableName, driver) =
     match driver with
@@ -541,25 +540,30 @@ module MigrationsAsyncImpl =
       return None
   }
 
-  let findLastAppliedAsync (connection: DbConnection) tableName = cancellableTask { // Changed signature
-    let! token = CancellableTask.getCancellationToken() // Get token from context
-    use command = connection.CreateCommand()
+  let findLastAppliedAsync
+    (connection: DbConnection)
+    (driver: MigrondiDriver)
+    (tableName: string)
+    =
+    cancellableTask {
+      let! token = CancellableTask.getCancellationToken()
 
-    command.CommandText <-
-      $"SELECT id, name, timestamp FROM %s{tableName} ORDER BY timestamp DESC LIMIT 1"
+      use command = connection.CreateCommand()
 
-    use! reader = command.ExecuteReaderAsync(token) // Use token
+      command.CommandText <- Queries.getFirstResultQuery(tableName, driver)
 
-    if reader.Read() then
-      return
-        Some {
-          id = reader.GetInt32(0)
-          name = reader.GetString(1)
-          timestamp = reader.GetInt64(2)
-        }
-    else
-      return None
-  }
+      use! reader = command.ExecuteReaderAsync(token) // Use token
+
+      if reader.Read() then
+        return
+          Some {
+            id = reader.GetInt32(0)
+            name = reader.GetString(1)
+            timestamp = reader.GetInt64(2)
+          }
+      else
+        return None
+    }
 
   let listMigrationsAsync (connection: DbConnection) (tableName: string) = cancellableTask { // Changed signature
     let! token = CancellableTask.getCancellationToken() // Get token from context
@@ -879,6 +883,7 @@ type internal MiDatabaseHandler(logger: ILogger, config: MigrondiConfig) =
       return!
         MigrationsAsyncImpl.findLastAppliedAsync
           connection
+          config.driver
           config.tableName
           token
     }

--- a/src/Migrondi/Commands.fs
+++ b/src/Migrondi/Commands.fs
@@ -62,7 +62,10 @@ module internal Commands =
       appEnv.Logger.LogError("Database was not setup", ex)
       reraise()
 
-    appEnv
+  let withSetup (appEnv: AppEnv) (action: 'args -> 'out) =
+    fun args ->
+      setup appEnv
+      action args
 
   let Init appEnv = command "init" {
     description
@@ -89,7 +92,8 @@ module internal Commands =
     addAlias "apply"
 
     inputs(SharedArguments.amount, SharedArguments.isDry)
-    setAction((setup >> ArgumentMapper.Up) appEnv)
+
+    setAction(withSetup appEnv (ArgumentMapper.Up appEnv))
   }
 
   let Down appEnv = command "down" {
@@ -97,7 +101,8 @@ module internal Commands =
     addAlias "rollback"
 
     inputs(SharedArguments.amount, SharedArguments.isDry)
-    setAction((setup >> ArgumentMapper.Down) appEnv)
+
+    setAction(withSetup appEnv (ArgumentMapper.Down appEnv))
   }
 
   let List appEnv = command "list" {
@@ -109,7 +114,7 @@ module internal Commands =
     inputs ListArgs.MigrationKind
 
     setAction(
-      (setup >> ArgumentMapper.List) appEnv >> Migrations.listMigrations
+      withSetup appEnv (ArgumentMapper.List appEnv >> Migrations.listMigrations)
     )
   }
 
@@ -122,6 +127,8 @@ module internal Commands =
     inputs(SharedArguments.name(Some "Name of the migration file"))
 
     setAction(
-      (setup >> ArgumentMapper.Status) appEnv >> Migrations.migrationStatus
+      withSetup
+        appEnv
+        (ArgumentMapper.Status appEnv >> Migrations.migrationStatus)
     )
   }

--- a/src/Migrondi/Env.fs
+++ b/src/Migrondi/Env.fs
@@ -49,12 +49,7 @@ module internal Configuration =
     let mutable tNO = None
     let mutable dO = None
 
-
-    rootCommand values {
-      description "Migrondi Configuration Parser"
-
-      configure(fun cfg ->
-        cfg.RootCommand.TreatUnmatchedTokensAsErrors <- false)
+    let cmd = ManualInvocation.rootCommand {
 
       inputs(connectionOption, migrationsOption, tableNameOption, driverOption)
 
@@ -70,7 +65,10 @@ module internal Configuration =
         tNO <- binder t
         dO <- binder d)
     }
-    |> ignore
+
+    cmd.TreatUnmatchedTokensAsErrors <- false
+
+    cmd.Parse(values).Invoke() |> ignore
 
     {|
       connection = cO

--- a/src/Migrondi/Migrondi.fsproj
+++ b/src/Migrondi/Migrondi.fsproj
@@ -21,7 +21,7 @@
     <ProjectReference Include="..\Migrondi.Core\Migrondi.Core.fsproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="FSharp.SystemCommandLine" Version="2.0.0-beta5.3" />
+    <PackageReference Include="FSharp.SystemCommandLine" Version="2.1.0" />
     <PackageReference Include="Serilog" Version="4.3.0" />
     <PackageReference Include="Serilog.Formatting.Compact" Version="3.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />

--- a/src/Migrondi/Program.fs
+++ b/src/Migrondi/Program.fs
@@ -41,13 +41,9 @@ let main argv =
   let cwd = $"{Environment.CurrentDirectory}{Path.DirectorySeparatorChar}"
   let appEnv = AppEnv.BuildDefault(cwd, logger, useJson, argv)
 
-  rootCommand argv {
+  let cmd = ManualInvocation.rootCommand {
     description
       "A dead simple SQL migrations runner, apply or rollback migrations at your ease"
-
-    configure(fun pipeline ->
-      // enable passing configuration flags before the actual commands
-      pipeline.RootCommand.TreatUnmatchedTokensAsErrors <- false)
 
     noAction
 
@@ -61,3 +57,7 @@ let main argv =
     ]
 
   }
+
+  cmd.TreatUnmatchedTokensAsErrors <- false
+
+  cmd.Parse(argv).Invoke()


### PR DESCRIPTION
## Summary

Fixes #40 — `migrondi up` against SQL Server failed (`Incorrect syntax near the keyword 'IF'` / `'dbo'`), plus a related startup crash that blocked reproduction.

## Root causes

This PR addresses two distinct bugs that were both shipped since `v1.0.1` (introduced in `c0d3d78`, the `FSharp.SystemCommandLine` migration).

### 1. SQL Server migrations were broken (`Migrondi.Core`)

The MSSQL migrations-history-table query had several issues that made `up`/`down`/`list`/`status` fail against SQL Server:

- **`GO` batch separator** — `createTable` ended with `GO`, which is a *client-side* batch separator (sqlcmd/SSMS) and is **not** valid T-SQL when sent over `SqlCommand`. This was the primary cause of the `Incorrect syntax near ...` errors in #40.
- **No `IDENTITY`** — the `id INT PRIMARY KEY` column had no auto-increment, so the `INSERT (name, timestamp)` that records an applied migration failed (`Cannot insert the value NULL into column 'id'`).
- **Hard-coded `dbo` schema** — `createTable` targeted `dbo.<table>` while every other query used the bare table name, breaking for users whose default schema isn't `dbo`. Dropped the hard-coded schema so it follows the connection's default schema (consistent with the other drivers).
- **`LIMIT 1` in the async path** — `findLastAppliedAsync` used `LIMIT 1` for *all* drivers, which is invalid T-SQL. The sync path already used `TOP 1`; the async path now reuses that helper (`getFirstResultQuery`) and gained the `driver` argument its twin already had.

### 2. Database setup ran eagerly for every CLI command (`Migrondi`)

`setAction((setup >> ArgumentMapper.X) appEnv)` partially applied `setup` at **command-construction** time, so the database setup (a side effect) ran for *every* command before parsing — regardless of which command was invoked.

- With SQLite + a valid connection this silently succeeded, so it went unnoticed.
- With any non-SQLite driver or an unreachable database, `setup` threw `SetupDatabaseFailed` during `addCommands`, meaning even `migrondi new`, `migrondi init`, and `migrondi --help` crashed (always attributed to the `up` command, since it was first in the list).

This is pure F# evaluation semantics — a function's argument is evaluated eagerly before the call, even when the result is a function — not a `FSharp.SystemCommandLine` issue (verified against the library: `setAction` only stores the action; invocation is deferred to `.Parse().Invoke()`).

**Fix:** `setup` now returns `unit`, and a `withSetup appEnv action` combinator defers it to invocation time. `Init`/`New` (pure composition, no setup) are unchanged.

## Changes

- `src/Migrondi.Core/Database.fs` — MSSQL `createTable` (`GO` removed, `IDENTITY(1,1)` added, `dbo` dropped); `findLastAppliedAsync` now takes `driver` and uses `getFirstResultQuery` (`TOP 1`).
- `src/Migrondi/Commands.fs` — `setup: unit`; added `withSetup`; Up/Down/List/Status defer setup via it.
- `src/Migrondi/Env.fs`, `src/Migrondi/Program.fs`, `src/Migrondi/Migrondi.fsproj` — move to `FSharp.SystemCommandLine` 2.1.0 (stable) and the manual-invocation root-command API.
- `CHANGELOG.md` — entries under `[Unreleased]`.

## Verification

Full lifecycle smoke-tested against **SQL Server 2022** (podman container):

1. `init` → 2. `new` → 3. `up` → 4. `down` → 5. `up` again → 6. `list` (1 Applied) → 7. `new` → 8. `list` (1 Applied, 1 Pending) — all green; history table created in the connection's default schema, migrations recorded/reverted correctly.

- `migrondi --help`/`new`/`init` no longer crash on a non-SQLite/unreachable config.
- `dotnet test src/Migrondi.Tests` — 64/64 passing (net8.0 + net10.0).
