### PR TITLE
Fix CLI JSON output, migration counts, and safer init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## [Unreleased]
 
+### Added
+
+- **MigrondiUI:** Logs a preview notice at startup — MigrondiUI is preview software (regardless of whether a release is marked stable, beta, or rc), expect breaking changes before it stabilizes at 2.0.
+
+### Changed
+
+- **Migrondi:** **Breaking (behavioral):** `init` no longer silently overwrites an existing `migrondi.json` — it now stops with an error so an existing project isn't clobbered. `--force` overwrites with the default configuration; `--force --merge` adopts the values already in the file instead (recovering known fields even from a partial or otherwise-invalid JSON), and `--merge` requires `--force`.
+
+### Fixed
+
+- **Migrondi.Core:** Apply/rollback reported the wrong numbers — the summary counted every pending/applied migration rather than the ones actually being processed, and applying nothing still returned the full migration history (so re-running `up` logged every already-applied migration as newly applied, and the MCP apply result over-counted). Counts and results now reflect only the migrations processed in that run.
+- **Migrondi:** `status` logged nothing for a valid migration and crashed when the name lacked a `.sql` suffix. It now reports `Applied` or `Pending` for a plain migration name (and a clean `NotFound` for an unknown one) in both human and JSON output.
+- **Migrondi:** JSON output for `list` (`[mi-json]`) embedded each migration as an escaped JSON string, forcing a second decode pass; migrations are now emitted as native JSON objects.
+
 ## [1.3.0-beta-001] - 2026-06-26
 
 ### Added

--- a/src/Migrondi.Core/Database.fs
+++ b/src/Migrondi.Core/Database.fs
@@ -413,22 +413,39 @@ module MigrationsImpl =
 
       executeMigration(migration, content, true)
 
-    // Replace RepoDB QueryAll with ADO.NET
-    use command = connection.CreateCommand()
+    let appliedRecords =
+      let migrationNames = migrations |> List.map(_.name)
 
-    command.CommandText <-
-      $"SELECT id, name, timestamp FROM {tableName} ORDER BY timestamp DESC"
+      if List.isEmpty migrationNames then
+        []
+      else
+        use command = connection.CreateCommand()
 
-    use reader = command.ExecuteReader()
+        let namePlaceholders =
+          String.Join(",", migrationNames |> List.mapi(fun i _ -> $"@name{i}"))
 
-    [ // Using list comprehension
-      while reader.Read() do
-        {
-          id = reader.GetInt32(0)
-          name = reader.GetString(1)
-          timestamp = reader.GetInt64(2)
-        }
-    ]
+        command.CommandText <-
+          Queries.getResultsByNamesQuery tableName namePlaceholders
+
+        migrationNames
+        |> List.iteri(fun i name ->
+          let param = command.CreateParameter()
+          param.ParameterName <- $"@name{i}"
+          param.Value <- name
+          command.Parameters.Add(param) |> ignore)
+
+        use reader = command.ExecuteReader()
+
+        [
+          while reader.Read() do
+            {
+              id = reader.GetInt32(0)
+              name = reader.GetString(1)
+              timestamp = reader.GetInt64(2)
+            }
+        ]
+
+    appliedRecords
 
   let rollbackMigrations
     (connection: DbConnection) // Changed to DbConnection
@@ -739,14 +756,29 @@ module MigrationsAsyncImpl =
 
         do! executeMigration(migration, content, true)
 
-      // Replace RepoDB QueryAllAsync with ADO.NET
-      use command = connection.CreateCommand()
+      let migrationNames = migrations |> List.map(_.name)
 
-      command.CommandText <- Queries.getAllResultsQuery tableName
+      if List.isEmpty migrationNames then
+        return []
+      else
+        use command = connection.CreateCommand()
 
-      use! reader = command.ExecuteReaderAsync token
+        let namePlaceholders =
+          String.Join(",", migrationNames |> List.mapi(fun i _ -> $"@name{i}"))
 
-      return! readMigrationRecords reader
+        command.CommandText <-
+          Queries.getResultsByNamesQuery tableName namePlaceholders
+
+        migrationNames
+        |> List.iteri(fun i name ->
+          let param = command.CreateParameter()
+          param.ParameterName <- $"@name{i}"
+          param.Value <- name
+          command.Parameters.Add(param) |> ignore)
+
+        use! reader = command.ExecuteReaderAsync token
+
+        return! readMigrationRecords reader
     }
 
   let rollbackMigrationsAsync

--- a/src/Migrondi.Core/Migrondi.fs
+++ b/src/Migrondi.Core/Migrondi.fs
@@ -191,7 +191,11 @@ module internal MigrondiserviceImpl =
           pendingMigrations
       | None -> pendingMigrations
 
-    logger.LogInformation $"Running '%i{pendingMigrations.Length}' migrations."
+    logger.LogInformation(
+      "Applying {MigrationCount} migration(s).",
+      migrationsToRun.Length
+    )
+
     db.ApplyMigrations migrationsToRun
 
   let runDown
@@ -229,8 +233,8 @@ module internal MigrondiserviceImpl =
       | None -> pendingMigrations
 
     logger.LogInformation(
-      "Reverting '{MigrationAmount}' migrations.",
-      pendingMigrations.Length
+      "Rolling back {MigrationCount} migration(s).",
+      migrationsToRun.Length
     )
 
     db.RollbackMigrations migrationsToRun
@@ -349,8 +353,10 @@ module internal MigrondiserviceImpl =
             pendingMigrations
         | None -> pendingMigrations
 
-      logger.LogInformation
-        $"Running '%i{pendingMigrations.Length}' migrations."
+      logger.LogInformation(
+        "Applying {MigrationCount} migration(s).",
+        migrationsToRun.Length
+      )
 
       return! db.ApplyMigrationsAsync(migrationsToRun, token)
     }
@@ -394,8 +400,8 @@ module internal MigrondiserviceImpl =
         | None -> pendingMigrations
 
       logger.LogInformation(
-        "Reverting '{MigrationAmount}' migrations.",
-        pendingMigrations.Length
+        "Rolling back {MigrationCount} migration(s).",
+        migrationsToRun.Length
       )
 
       return! db.RollbackMigrationsAsync migrationsToRun

--- a/src/Migrondi.Tests/Database.Async.fs
+++ b/src/Migrondi.Tests/Database.Async.fs
@@ -322,6 +322,33 @@ type DatabaseAsyncTests() =
     :> Task
 
   [<TestMethod>]
+  member _.``ApplyMigrationsAsync returns only the migrations applied in the same call``
+    ()
+    =
+    task {
+      let! operation = asyncResult {
+        let sampleMigrations = DatabaseData.createTestMigrations 3
+
+        let! firstBatch = databaseEnv.ApplyMigrationsAsync(sampleMigrations)
+
+        do!
+          firstBatch
+          |> Result.requireNotEmpty "The first batch should apply migrations"
+
+        let! emptyBatch = databaseEnv.ApplyMigrationsAsync([])
+
+        return (firstBatch, emptyBatch)
+      }
+
+      match operation with
+      | Ok(firstBatch, emptyBatch) ->
+        Assert.AreEqual<int>(4, firstBatch.Count)
+        Assert.AreEqual<int>(0, emptyBatch.Count)
+      | Error err -> Assert.Fail($"Failed: %s{err}")
+    }
+    :> Task
+
+  [<TestMethod>]
   member _.``RollBackMigrations Should rollback migrations and return the migrations left in the database``
     ()
     =

--- a/src/Migrondi.Tests/Database.fs
+++ b/src/Migrondi.Tests/Database.fs
@@ -381,6 +381,32 @@ type DatabaseTests() =
       Assert.Fail($"Failed to find the last applied migration: %s{err}")
 
   [<TestMethod>]
+  member _.``ApplyMigrations returns only the migrations applied in the same call``
+    ()
+    =
+    let operation = result {
+      do databaseEnv.SetupDatabase()
+
+      let sampleMigrations = DatabaseData.createTestMigrations 3
+
+      let firstBatch = databaseEnv.ApplyMigrations(sampleMigrations)
+
+      do!
+        firstBatch
+        |> Result.requireNotEmpty "The first batch should apply migrations"
+
+      let emptyBatch = databaseEnv.ApplyMigrations([])
+
+      return (firstBatch, emptyBatch)
+    }
+
+    match operation with
+    | Ok(firstBatch, emptyBatch) ->
+      Assert.AreEqual<int>(4, firstBatch.Count)
+      Assert.AreEqual<int>(0, emptyBatch.Count)
+    | Error err -> Assert.Fail($"Failed: %s{err}")
+
+  [<TestMethod>]
   member _.``RollBackMigrations Should roll back migrations and return the migrations that were reverted from the database``
     ()
     =

--- a/src/Migrondi/Commands.fs
+++ b/src/Migrondi/Commands.fs
@@ -13,13 +13,21 @@ open Migrondi.Handlers
 module internal ArgumentMapper =
 
 
-  let Init (appEnv: AppEnv) (dir: DirectoryInfo option) =
+  let Init
+    (appEnv: AppEnv)
+    (dir: DirectoryInfo option, force: bool option, merge: bool option)
+    =
     let path =
       match dir with
       | Some directory -> directory
       | None -> Directory.GetCurrentDirectory() |> DirectoryInfo
 
-    path, appEnv.FileSystem, appEnv.Logger
+    path,
+    appEnv.FileSystem,
+    appEnv.ConfigurationSerializer,
+    appEnv.Logger,
+    force,
+    merge
 
   let Up (appEnv: AppEnv) (amount: int option, isDry: bool option) =
     match isDry with
@@ -40,11 +48,7 @@ module internal ArgumentMapper =
     name, manualTransaction, appEnv.Logger, appEnv.Migrondi
 
   let inline List (appEnv: AppEnv) (kind: MigrationType option) =
-    appEnv.JsonOutput,
-    appEnv.Logger,
-    appEnv.MigrationSerializer,
-    kind,
-    appEnv.Migrondi
+    appEnv.JsonOutput, appEnv.Logger, kind, appEnv.Migrondi
 
   let inline Status (appEnv: AppEnv) (name: string) =
     name, appEnv.Logger, appEnv.Migrondi
@@ -73,7 +77,7 @@ module internal Commands =
 
     addAlias "setup"
 
-    inputs Init.path
+    inputs(Init.path, Init.force, Init.merge)
     setAction(ArgumentMapper.Init appEnv >> Init.handler)
   }
 

--- a/src/Migrondi/Handlers.fs
+++ b/src/Migrondi/Handlers.fs
@@ -2,6 +2,7 @@ namespace Migrondi.Handlers
 
 open System
 open System.IO
+open System.Text.Json
 
 open System.Security
 open Microsoft.Extensions.Logging
@@ -10,19 +11,202 @@ open Spectre.Console
 open Migrondi.Core
 open Migrondi.Core.Serialization
 open Migrondi.Core.FileSystem
+open FsToolkit.ErrorHandling
 
 [<RequireQualifiedAccess>]
 module internal Init =
-  let handler(path: DirectoryInfo, fs: IMiFileSystem, logger: ILogger) =
+
+  type private LoadingFileError =
+    | FileNotFound
+    | FoundButUnparsable
+
+  let private recoverConfig(values: Map<string, string>) : MigrondiConfig =
+    let defaults = MigrondiConfig.Default
+
+    let driver =
+      values
+      |> Map.tryFind "driver"
+      |> Option.bind(fun value ->
+        try
+          MigrondiDriver.FromString value |> Some
+        with _ ->
+          None)
+      |> Option.defaultValue defaults.driver
+
+    {
+      connection =
+        values
+        |> Map.tryFind "connection"
+        |> Option.defaultValue defaults.connection
+      migrations =
+        values
+        |> Map.tryFind "migrations"
+        |> Option.defaultValue defaults.migrations
+      tableName =
+        values
+        |> Map.tryFind "tableName"
+        |> Option.defaultValue defaults.tableName
+      driver = driver
+    }
+
+  let private (|HardStop|MergeUnforced|ForceClean|ForceMerge|CleanSetup|)
+    (isEmpty, force, merge)
+    =
+    match isEmpty, force, merge with
+    | _, false, true -> MergeUnforced
+    | false, true, true -> ForceMerge
+    | true, _, false -> CleanSetup
+    | false, true, false -> ForceClean
+    | true, _, _ -> ForceClean
+    | false, false, _ -> HardStop
+
+  let private isDirectoryEmpty(path: DirectoryInfo) =
+    try
+      let noDirs =
+        Directory.EnumerateDirectories(
+          path.FullName,
+          "*",
+          SearchOption.AllDirectories
+        )
+        |> Seq.isEmpty
+
+      let noFiles =
+        Directory.EnumerateFiles(
+          path.FullName,
+          "*",
+          SearchOption.AllDirectories
+        )
+        |> Seq.isEmpty
+
+      noDirs && noFiles
+    with :? DirectoryNotFoundException ->
+      path.Create()
+      true
+
+  let private loadConfig
+    (path: DirectoryInfo)
+    (configPath: string)
+    (serializer: IMiConfigurationSerializer)
+    (logger: ILogger)
+    : Result<MigrondiConfig, LoadingFileError> =
+    let textContent =
+      try
+        File.ReadAllText configPath |> Ok
+      with
+      | :? DirectoryNotFoundException ->
+        path.Create()
+        Error FileNotFound
+      | :? FileNotFoundException -> Error FileNotFound
+
+    try
+      textContent
+      |> Result.map serializer.Decode
+      |> Result.tee(fun _ ->
+        logger.LogInformation("Found migrondi.json at {Path}", path.FullName))
+    with :? DeserializationFailed ->
+      try
+        textContent
+        |> Result.tee(fun _ ->
+          logger.LogWarning(
+            "Found an invalid migrondi.json file at {Path}",
+            path.FullName
+          ))
+        |> Result.map(
+          JsonSerializer.Deserialize<Map<string, string>> >> recoverConfig
+        )
+      with :? JsonException ->
+        logger.LogWarning "migrondi.json file is not valid json"
+        Error FoundButUnparsable
+
+  let private migrationsDirectory
+    (path: DirectoryInfo)
+    (config: MigrondiConfig)
+    =
+    if
+      Path.IsPathRooted config.migrations
+      || Path.IsPathFullyQualified config.migrations
+    then
+      DirectoryInfo config.migrations
+    else
+      path.CreateSubdirectory config.migrations
+
+  let private hasExistingMigrations
+    (path: DirectoryInfo)
+    (config: MigrondiConfig)
+    =
+    let dir = migrationsDirectory path config
+
+    let files =
+      try
+        dir.EnumerateFiles(
+          "*.sql",
+          EnumerationOptions(
+            MatchCasing = MatchCasing.CaseInsensitive,
+            RecurseSubdirectories = false
+          )
+        )
+      with :? DirectoryNotFoundException ->
+        dir.Create()
+        Seq.empty
+
+    files |> Seq.isEmpty |> not
+
+  let private runForceMerge
+    (path: DirectoryInfo)
+    (fs: IMiFileSystem)
+    (configPath: string)
+    (serializer: IMiConfigurationSerializer)
+    (logger: ILogger)
+    =
+    let config =
+      loadConfig path configPath serializer logger
+      |> Result.defaultValue MigrondiConfig.Default
+
+    logger.LogInformation(
+      "Initializing a migrondi project at {PathName}",
+      path.FullName
+    )
+
+    fs.WriteConfiguration(config, configPath)
+
+    if hasExistingMigrations path config then
+      logger.LogWarning(
+        "Sql Files already existing in {MigrationsDir}, leaving untouched.",
+        config.migrations
+      )
+
+    logger.LogInformation "Migrondi project merged and ready to work."
+    0
+
+  let private runCleanSetup
+    (path: DirectoryInfo)
+    (fs: IMiFileSystem)
+    (configPath: string)
+    (logger: ILogger)
+    =
     logger.LogInformation(
       "Initializing a new migrondi project at: {PathName}.",
       path.FullName
     )
 
-    let configPath = Path.Combine(path.FullName, "./migrondi.json")
     let config = MigrondiConfig.Default
+    let migrationsDirPath = Path.Combine(path.FullName, config.migrations)
+
+    try
+      Directory.Delete(migrationsDirPath, true)
+    with
+    | :? IOException
+    | :? UnauthorizedAccessException ->
+      logger.LogWarning(
+        "Unable to delete the migrations directory at {MigrationsDir}",
+        migrationsDirPath
+      )
+
+    path.Create()
+
     fs.WriteConfiguration(config, configPath)
-    let subpath = path.CreateSubdirectory(config.migrations)
+
+    let subpath = path.CreateSubdirectory config.migrations
 
     logger.LogInformation(
       "migrondi.json and {MigrationsDirectory} directory created successfully.",
@@ -30,6 +214,34 @@ module internal Init =
     )
 
     0
+
+  let handler
+    (
+      path: DirectoryInfo,
+      fs: IMiFileSystem,
+      serializer: IMiConfigurationSerializer,
+      logger: ILogger,
+      force: bool option,
+      merge: bool option
+    ) =
+    let force = defaultArg force false
+    let merge = defaultArg merge false
+    let configPath = Path.Combine(path.FullName, "./migrondi.json")
+
+    match (isDirectoryEmpty path, force, merge) with
+    | ForceMerge -> runForceMerge path fs configPath serializer logger
+    | CleanSetup
+    | ForceClean -> runCleanSetup path fs configPath logger
+    | MergeUnforced ->
+      logger.LogError "--merge can only be used together with --force."
+      1
+    | HardStop ->
+      logger.LogError(
+        "The Directory {ConfigPath} is not empty. Use --force to overwrite it, or --force --merge to adopt its current values.",
+        path.FullName
+      )
+
+      1
 
 
 [<RequireQualifiedAccess>]
@@ -154,7 +366,6 @@ module internal Migrations =
     (
       useJson: bool,
       logger: ILogger,
-      serializer: IMiMigrationSerializer,
       kind: MigrationType option,
       migrondi: IMigrondi
     ) =
@@ -215,23 +426,41 @@ module internal Migrations =
       AnsiConsole.Write table
 
     let printJson(migrations: Migration seq, status: string) =
-      let encoded = migrations |> Seq.map(fun m -> serializer.EncodeJson m)
+      let data =
+        migrations
+        |> Seq.map(fun m -> {|
+          name = m.name
+          timestamp = m.timestamp
+          upContent = m.upContent
+          downContent = m.downContent
+          manualTransaction = m.manualTransaction
+        |})
 
       logger.LogInformation(
-        "Listing {Status} migrations: {Migrations}",
+        "Listing {Status} migrations: {@Migrations}",
         status,
-        encoded
+        data
       )
 
     let printJsonBoth(migrations: MigrationStatus seq) =
-      let encoded =
+      let data =
         migrations
         |> Seq.map(fun status ->
-          match status with
-          | Applied m -> ("Applied", serializer.EncodeJson m)
-          | Pending m -> ("Pending", serializer.EncodeJson m))
+          let tag, m =
+            match status with
+            | Applied m -> "Applied", m
+            | Pending m -> "Pending", m
 
-      logger.LogInformation("Listing migrations: {Migrations}", encoded)
+          {|
+            status = tag
+            name = m.name
+            timestamp = m.timestamp
+            upContent = m.upContent
+            downContent = m.downContent
+            manualTransaction = m.manualTransaction
+          |})
+
+      logger.LogInformation("Listing migrations: {@Migrations}", data)
 
     let allMigrations = migrondi.MigrationsList()
 
@@ -275,22 +504,35 @@ module internal Migrations =
     0
 
   let migrationStatus(name: string, logger: ILogger, migrondi: IMigrondi) =
-    let formatTimestamp timestamp =
-      let date =
-        DateTimeOffset.FromUnixTimeMilliseconds(timestamp).ToLocalTime()
+    let fileName =
+      if name.EndsWith(".sql", StringComparison.OrdinalIgnoreCase) then
+        name
+      else
+        $"{name}.sql"
 
-      date.ToString()
+    try
+      match migrondi.ScriptStatus fileName with
+      | Applied migration ->
+        logger.LogInformation(
+          "Migration {MigrationName} (timestamp {Timestamp}) is {Status}.",
+          migration.name,
+          migration.timestamp,
+          "Applied"
+        )
+      | Pending migration ->
+        logger.LogInformation(
+          "Migration {MigrationName} (timestamp {Timestamp}) is {Status}.",
+          migration.name,
+          migration.timestamp,
+          "Pending"
+        )
 
-    match migrondi.ScriptStatus(name) with
-    | Applied migration ->
-      logger.LogInformation(
-        "Migration {migration.name} was created on '{Timestamp}' and is currently applied.",
-        formatTimestamp(migration.timestamp)
+      0
+    with :? SourceNotFound ->
+      logger.LogWarning(
+        "No migration found with name {MigrationName} ({Status}).",
+        name,
+        "NotFound"
       )
-    | Pending migration ->
-      logger.LogInformation(
-        "Migration {migration.name} was created on '{Timestamp}' and is not currently applied.",
-        formatTimestamp(migration.timestamp)
-      )
 
-    0
+      0

--- a/src/Migrondi/Inputs.fs
+++ b/src/Migrondi/Inputs.fs
@@ -16,6 +16,15 @@ module Init =
     Input.argumentMaybe<DirectoryInfo> "path"
     |> Input.desc "path to initialize a migrondi configuration file"
 
+  let force =
+    Input.optionMaybe<bool> "--force"
+    |> Input.desc "Overwrite an existing migrondi.json"
+
+  let merge =
+    Input.optionMaybe<bool> "--merge"
+    |> Input.desc
+      "With --force, adopt values from an existing migrondi.json instead of overwriting with defaults"
+
 [<RequireQualifiedAccess>]
 module SharedArguments =
 

--- a/src/MigrondiUI/Program.fs
+++ b/src/MigrondiUI/Program.fs
@@ -95,6 +95,16 @@ type App() as this =
 
 [<EntryPoint; STAThread>]
 let main argv =
+  let logger = loggerFactory.CreateLogger "MigrondiUI"
+
+  logger.LogInformation
+    "Migrondi UI is currently in preview if you can see this notice, regardless of the reported version (stable or marked as beta/rc)."
+
+  logger.LogInformation
+    "things are subject to change, and will likely break in the up coming releases."
+
+  logger.LogInformation "We expect to stabilize Migrondi UI by 2.0."
+
   match Server.tryParseArgs argv with
   | Some mcpOptions ->
     Server.runMcpServer Database.ConnectionFactory mcpOptions loggerFactory


### PR DESCRIPTION
## Summary

Follow-up to `1.3.0-beta-001` focused on making the CLI's `[mi-json]` output reliable for AI/tooling consumption, fixing inaccurate apply/rollback counts, and making `init` safe by default. Also adds a preview notice to MigrondiUI.

## Changed / Fixed

**`status` (fix)** — Previously logged nothing for a valid migration and crashed with an unhandled `SourceNotFound` stack trace when the name lacked a `.sql` suffix. The log template had an invalid dotted placeholder (`{migration.name}`) with a mismatched argument count, so Serilog swallowed the render. It now reports `Applied` / `Pending` (and a clean `NotFound`) for a plain migration name (`ts_name`, with or without `.sql`), in both human and JSON output.

**`list` JSON (fix)** — `[mi-json]` output embedded each migration as an escaped JSON string nested inside the Serilog payload (a `[status, "<stringified-json>"]` tuple), forcing a second decode pass and duplicating the data in `@m`. Migrations are now passed as native objects with the `@` destructure hint, so `Migrations` is a real JSON array of objects.

**Apply/rollback counts (fix)** —
- The summary counted every pending/applied migration rather than the ones actually being processed (`down 1` with 2 applied logged "Reverting '2'"). It now reports `MigrationCount` for the migrations actually being run.
- `applyMigrations` returned the **entire** migration history instead of just-applied records, so a no-op `up` still logged every already-applied migration as newly applied (and the MCP `runMigrations` result over-counted). It now returns only the records applied in that call, mirroring `rollbackMigrations`. This also corrects the MCP apply/rollback results.

**`init` (breaking behavioral)** — `init` no longer silently overwrites an existing `migrondi.json`:
- no flags + existing project → hard stop with a clear error
- `--force` → overwrite the config and reset **only** the migrations directory (other files are preserved; the earlier whole-directory wipe is gone)
- `--force --merge` → adopt the values already in the file (canonical decode first; on failure, recover known fields from a loose `Map<string,string>` via `System.Text.Json` + `MigrondiDriver.FromString`; an unreadable file is discarded to defaults)
- `--merge` requires `--force`

**MigrondiUI (added)** — Logs a preview notice at startup: MigrondiUI is preview software (regardless of whether a release is marked stable/beta/rc), expect breaking changes before it stabilizes at 2.0.

## Tests

- Existing suite stays green: **66/66** on net8.0 and net10.0.
- Added two regression tests (`Database.fs` / `Database.Async.fs`): applying an empty batch must return empty even when the history table has rows — pins the root cause of the over-counting.
- Smoke-tested every CLI command against a SQL Server 2022 container (`status`, `list` all/up/down, `up`/`down` real + dry, idempotent `up`) and the full `init` matrix (empty, non-existent, hard-stop, `--merge`-without-`--force`, `--force`, `--force --merge` valid/partial/garbage) in both `[mi-json]` and plain modes.

## CHANGELOG

Entries added under `[Unreleased]` (`Added`, `Changed`, `Fixed`).
